### PR TITLE
Improve the readme to resolve TODOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ yarn add -D @arcanis/sherlock
 Then create a new [GitHub Workflow](https://help.github.com/en/articles/configuring-workflows) with the following content:
 
 ```yml
-on: [issues]
+on:
+  issues:
+    types: [opened, edited, unlabeled]
 
 name: Sherlock
 jobs:
@@ -186,7 +188,6 @@ The reason why we do all this in three steps (rather than a single one) is that 
 
 Some things that GitHub could do to make Sherlock better integrated:
 
-- support a copy button on code blocks (this way we can just copy the repro to try it out locally)
 - support CI-like status for issues (this way we could avoid polluting the comment thread)
 - support for fine-tuned triggers (this way we could avoid spawning the workflow for issue events we don't care)
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ The reason why we do all this in three steps (rather than a single one) is that 
 Some things that GitHub could do to make Sherlock better integrated:
 
 - support CI-like status for issues (this way we could avoid polluting the comment thread)
-- support for fine-tuned triggers (this way we could avoid spawning the workflow for issue events we don't care)
 
 ## License (MIT)
 


### PR DESCRIPTION
- GitHub has implemented the copy button for code blocks: https://github.blog/2021-06-10-whats-new-from-github-changelog-may-2021-recap/#markdown
- GitHub Actions actually supports fine-grained triggers: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#issues